### PR TITLE
Fix #53 pygats: added bill of materials

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy==1.24.2
+Pillow==9.4.0
+pyautogui==0.9.53
+pyperclip==1.8.2
+pytesseract==0.3.10
+pytest==7.2.2
+python_Levenshtein==0.20.9


### PR DESCRIPTION
SBOM was generated by pipreqs for python 3.10
Signed-off-by: Maxim Korotkov <korotkov.maxim.s@gmail.com>