### PR TITLE
Add return value to the check_text function to create conditions with this function

### DIFF
--- a/src/pygats/recog.py
+++ b/src/pygats/recog.py
@@ -127,7 +127,9 @@ def check_text(ctx, img: Image, txt):
         _, found = find_text(ctx, img, txt, extend=True)
         if not found:
             failed(msg=f'{txt.content} не найден на изображении')
+            return False
     passed(ctx)
+    return True
 
 
 def check_text_on_screen(ctx, txt):


### PR DESCRIPTION
Due to the fact that the check_text function does not return any value, I suggest adding 2 returns, since, for example, the function can find an image, but not find the desired text. using return value, it will be possible to understand whether a particular action is successfully performed or not, in addition to the results of passed and failed. accordingly, it will be possible to create conditions with check_text