### PR TITLE
Fix linter R0917 error (too many positional arguments) to pass checks in github actions

### DIFF
--- a/src/pygats/recog.py
+++ b/src/pygats/recog.py
@@ -313,7 +313,7 @@ def find_crop_image(img: Image, crop_area: Optional[str] = 'all',
         else (0, 0, img)
 
 
-def find_text(ctx, img: Image, txt, skip=0, extend=False, one_word=False):
+def find_text(ctx, img: Image, txt, skip=0, extend=False, one_word=False):  # pylint: disable=R0917
     """Function finds text in image with Tesseract
 
     Args:


### PR DESCRIPTION
When execute the push, the code does not pass the github actions check, as error R0917 occurs related to positional arguments. To solve the problem, need to add a restriction on checking linter for a part of the code so that this does not apply to the entire API of the library

In conclusion, after check github actions, expect the error to be fixed