### PR TITLE
Create tests for find_keypoints and hdbscan_cluster functions

### DIFF
--- a/src/pygats/recog.py
+++ b/src/pygats/recog.py
@@ -13,7 +13,7 @@ import numpy as np
 import cv2 as cv
 from Levenshtein import ratio
 from PIL import Image
-from pygats.pygats import step, passed, failed
+from src.pygats.pygats import step, passed, failed
 
 
 @dataclass

--- a/src/pygats/recog.py
+++ b/src/pygats/recog.py
@@ -496,7 +496,10 @@ def find_keypoints(img: Image):
             descriptors (numpy.ndarray): Computed descriptors
             coord_list (numpy.ndarray): Array of coordinates of keypoints
     """
-    gray = cv.cvtColor(np.array(img), cv.COLOR_BGR2GRAY)
+    if img.mode == "L":
+        gray = np.array(img)
+    else:
+        gray = cv.cvtColor(np.array(img), cv.COLOR_BGR2GRAY)
     sift = cv.SIFT_create()
     keypoints, descriptors = sift.detectAndCompute(gray, None)
     coord_list = []

--- a/src/pygats/recog.py
+++ b/src/pygats/recog.py
@@ -13,7 +13,7 @@ import numpy as np
 import cv2 as cv
 from Levenshtein import ratio
 from PIL import Image
-from src.pygats.pygats import step, passed, failed
+from pygats.pygats import step, passed, failed
 
 
 @dataclass

--- a/tests/test_recog.py
+++ b/tests/test_recog.py
@@ -23,6 +23,16 @@ def fixture_create_ctx(formatter: MD):
 
 
 @pytest.fixture(scope="function")
+def gen_photo():
+    img = Image.open(f'tests/find/background/blue.jpg')
+    font = ImageFont.truetype(f'tests/find/fonts/Arial.ttf', size=50)
+    draw_text = ImageDraw.Draw(img)
+    draw_text.text((350, 350), "TEST", font=font, fill=('#000000'))
+    img.save('tests/find/1.png')
+    return img
+
+
+@pytest.fixture(scope="function")
 def words_for_bg():
     gen.color_shade_gen((85, 85, 85), (350, 350))
     file = open("tests/find/words.en.txt")
@@ -101,3 +111,25 @@ def test_contrast(img_path, expected_value):
     img = Image.open(img_path)
     contrast = rec.contrast(img)
     assert math.isclose(contrast, expected_value, rel_tol=1e-09, abs_tol=0.0)
+
+
+@pytest.mark.parametrize(
+    "img_path",
+    [
+        ("tests/find/background/yellow-grad.jpg"),
+        ("tests/find/background/white.jpg"),
+    ]
+)
+def test_find_keypoints_failed(img_path):
+    img = Image.open(img_path)
+    img.transpose(Image.ROTATE_90)
+    keypoints, _, _ = rec.find_keypoints(img)
+    assert keypoints == ()
+
+
+def test_find_keypoints_success(gen_photo):
+    gen_photo
+    img = Image.open("tests/find/1.png")
+    img.transpose(Image.ROTATE_90)
+    keypoints, _, _ = rec.find_keypoints(img)
+    assert len(keypoints) > 0


### PR DESCRIPTION
Create a test for find_text that checks

a) color models of the image
b) rotation
c) missing key points
d) search for key points on the image created using the fixture 

Also improve the find_keypoints function, since an error was displayed when processing a previously converted image, for example, image mode = "L"

Tests for hdbscan_cluster in development